### PR TITLE
Switch to options bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ error with contextual message. Besides, no consensus on which property will
 representing the cause makes it not feasible for developer tools to revealing
 contextual information of causes.
 
-The proposed solution is adding an additional parameter `cause` to the
-`Error()` constructor, and the value of the parameter will be assigned to
-the error instances as a property. So errors can be chained without
+The proposed solution is adding an additional options parameter to the `Error()`
+constructor with a `cause` property, the value of which will be assigned
+to the error instances as a property. So errors can be chained without
 unnecessary and overelaborate formalities on wrapping the errors in
 conditions.
 
@@ -60,12 +60,12 @@ conditions.
 async function doJob() {
   const rawResource = await fetch('//domain/resource-a')
     .catch(err => {
-      throw new Error('Download raw resource failed', err);
+      throw new Error('Download raw resource failed', { cause: err });
     });
   const jobResult = doComputationalHeavyJob(rawResource);
   await fetch('//domain/upload', { method: 'POST', body: jobResult })
     .catch(err => {
-      throw new Error('Upload job result failed', err);
+      throw new Error('Upload job result failed', { cause: err });
     });
 }
 
@@ -87,6 +87,8 @@ assigned to newly constructed error instances with the name `fileName` and
 `lineNumber` respectively.
 
 However, no standard on either ECMAScript or Web were defined on such behavior.
+Since the second parameter under this proposal must be an object with a `cause`
+property, it will be distinguishable from a string.
 
 ## FAQs
 


### PR DESCRIPTION
Fixes #11

@legendecas since #11 was reopened, I thought why not create a PR to update the proposal itself. Not sure if this process can be quite as simple as this for a Stage 2 proposal (this is one way to find out I guess)!

Note that this also fixes the backwards-compatibility concern with Firefox.

Previously, this proposal could run into trouble if raw strings are thrown. Say you're using a function like:

```js
const foo = () => {
  if (Math.random() < 0.5) {
    throw 'bad luck'
  }
}
```

Before this change, the proposal would have users do something like:

```js
try {
  foo()
} catch (e) {
  throw new Error('Do something failed!', e)
}
```

Which in most environments, would create an Error with `cause: 'bad luck'`. But in Firefox it'd be `fileName: 'bad luck'`. The suggested usage would now be:

```js
try {
  foo()
} catch (e) {
  throw new Error('Do something failed!', { cause: e })
}
```

Switching to an options bag will allow Firefox to continue to interpret the second parameter as `fileName` if it's a string, and an options bag if it's an object (with a `cause` property).

CC @00ff0000red